### PR TITLE
fix: allow forward slash in module name

### DIFF
--- a/src/commands/skuid/page/pull.ts
+++ b/src/commands/skuid/page/pull.ts
@@ -91,7 +91,7 @@ export default class Pull extends SfdxCommand {
     Object.entries(skuidPages).forEach(([ pageName, skuidPage]) => {
       numPages++;
       if (pageName.startsWith('_')) pageName = pageName.substring(1);
-      pageName = pageName.replace('/', '-');
+      pageName = pageName.replace(/[\/\\]/g, '');
       const pageBasePath: string = resolve(dir, pageName);
       // Trim leading _ off of the name, which will happen for pages not in a module
       const xml: string = skuidPage.body || skuidPage.content;

--- a/src/commands/skuid/page/pull.ts
+++ b/src/commands/skuid/page/pull.ts
@@ -74,6 +74,11 @@ export default class Pull extends SfdxCommand {
           result[pageName.substring(1)] = pageResult;
           delete result[pageName];
         }
+        const newName = pageName.replace(/[\/\\]/g, '');
+        if (pageName !== newName) {
+          result[newName] = result[pageName];
+          delete result[pageName];
+        }
       });
       return {
         pages: result

--- a/src/commands/skuid/page/pull.ts
+++ b/src/commands/skuid/page/pull.ts
@@ -91,6 +91,7 @@ export default class Pull extends SfdxCommand {
     Object.entries(skuidPages).forEach(([ pageName, skuidPage]) => {
       numPages++;
       if (pageName.startsWith('_')) pageName = pageName.substring(1);
+      pageName = pageName.replace('/', '-');
       const pageBasePath: string = resolve(dir, pageName);
       // Trim leading _ off of the name, which will happen for pages not in a module
       const xml: string = skuidPage.body || skuidPage.content;
@@ -106,7 +107,6 @@ export default class Pull extends SfdxCommand {
       // Clear out memory from our response
       delete skuidPages[pageName];
     });
-
     this.ux.log('Wrote ' + numPages + ' pages to ' + dir);
 
     return {};

--- a/test/commands/skuid/page/pull.test.ts
+++ b/test/commands/skuid/page/pull.test.ts
@@ -15,9 +15,9 @@ const v1PageObject = {
 
 const v1PageObjectWithSlashModule = {
   "apiVersion": "v1",
-  "name": "SomePageName",
-  "module": "foo/bar",
-  "uniqueId": "foo/bar_SomePageName",
+  "name": "Some/Page\\Name",
+  "module": "foo/bar\\baz",
+  "uniqueId": "foo/bar\\baz_Some/Page\\Name",
   "composerSettings": null,
   "maxAutoSaves": "100",
   "body": "<skuidpage><models/></skuidpage>"
@@ -105,16 +105,16 @@ describe('skuid:page:pull', () => {
     .withOrg({ username: 'test@org.com' }, true)
     .withConnectionRequest(request => {
       const requestMap = ensureJsonMap(request);
-      if (ensureString(requestMap.url).match(/services\/apexrest\/skuid\/api\/v1\/pages\?module=foo%2Fbar/)) {
+      if (ensureString(requestMap.url).match(/services\/apexrest\/skuid\/api\/v1\/pages\?module=foo%2Fbar%5Cbaz/)) {
         return Promise.resolve(JSON.stringify({
-          "foo/bar_SomePageName": v1PageObjectWithSlashModule,
+          "foo/bar\\baz_Some/Page\\Name": v1PageObjectWithSlashModule,
         }));
       }
       return Promise.reject(new Error("Unexpected request"));
     })
     .stdout()
-    .command(['skuid:page:pull', '--targetusername', 'test@org.com', '--module', 'foo/bar'])
-    .it('only requests pages in specific module and replace / with -', ctx => {
+    .command(['skuid:page:pull', '--targetusername', 'test@org.com', '--module', 'foo/bar\\baz'])
+    .it('removes unsafe directory characters from at-rest file names', ctx => {
       expect(ctx.stdout).to.contain('Wrote 1 pages to skuidpages');
     });
 


### PR DESCRIPTION
Allows for a Salesforce Skuid module to have a `/` in the name and not error out because of a bad file write. By using the `-` character instead, the format of `moduleName_pageName` is still preserved, while properly allowing the character to still be there.

As `replace` will only replace if the value is found, there is no need to worry about an if check before using the function.

Fix: #6 