### PR TITLE
Switch to using tabs for indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ SFDX plugin for managing Skuid metadata
 <!-- install -->
 # Installation
 
- First, ensure you have [installed `sfdx`](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm).
+First, ensure you have [installed `sfdx`](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm).
 
-  Now, install the skuid-sfdx plugin:
-
+Now, install the skuid-sfdx plugin:
 
 ```sh-session
 echo 'y' | sfdx plugins:install skuid-sfdx
@@ -38,6 +37,16 @@ To use `skuid-sfdx` in a CI environment, you will either need to auto-trust the 
 
 <!-- usage -->
 # Usage
+
+To pull Skuid Pages from a Salesforce org to the filesystem, use the `skuid:page:pull` command. You can use various arguments to specify which Pages in the org you want to pull, and you can output the pages to a directory of your choice.
+
+For each Page, two files will be written:
+
+  - an XML file containing the Page's layout
+  - a JSON file containing metadata about the Page
+
+### Example
+
 ```sh-session
 
 $ sfdx skuid:page:pull
@@ -45,11 +54,19 @@ Wrote 85 pages to skuidpages
 
 $ sfdx skuid:page:pull --module SamplePages --dir pages/sample
 Wrote 4 pages to pages/sample
+```
+
+Page XML will be pretty-printed, with indentation automatically added, to make it easy to review and commit changes to Skuid Pages line-by-line to source control. (Note: tabs are used for indentation by default, but if you would like to use a different indentation, you can set the `SKUID_XML_INDENT` environment variable, e.g. `export SKUID_XML_INDENT="  "` to use 2 spaces instead of tabs.)
+
+Going the other direction, to move Skuid Pages from the filesystem up to a Salesforce org, use the `skuid:page:push` command. You can use file glob patterns to specify which Pages in your filesystem that you want to push, for example:
+
+```sh-session
 
 $ sfdx skuid:page:push salesapp/*Foo*
 3 Pages successfully pushed.
 
 ```
+
 <!-- usagestop -->
 
 <!-- commands -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skuid-sfdx",
   "description": "SFDX plugin for managing Skuid metadata",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Skuid",
   "bugs": "https://github.com/skuid/skuid-sfdx/issues",
   "dependencies": {

--- a/src/helpers/xml.ts
+++ b/src/helpers/xml.ts
@@ -1,14 +1,15 @@
 import { xml, xmlmin } from 'vkbeautify';
 
-const PADDING = ' '.repeat(2); // set desired indent size here
-
 /**
  * Pretty-prints a string of XML, adding indentation and newlines between tags
  * @param condensedXml {String} Skuid Page XML
  * @returns {String}
  */
 function formatXml(condensedXml: string): string {
-    return xml(condensedXml, PADDING);
+    // For consistency across all of Skuid, use tabs for pretty printing of XML by default.
+    // However, allow for this to be configurable via an environment variable.
+    const indent = process.env.SKUID_XML_INDENT || '\t';
+    return xml(condensedXml, indent);
 }
 
 /**

--- a/test/helpers/xml.test.ts
+++ b/test/helpers/xml.test.ts
@@ -2,68 +2,72 @@
 import { condenseXml, formatXml } from "../../src/helpers/xml";
 import { expect } from '@salesforce/command/lib/test';
 
-const formatted = `<skuid__page>
-  <models>
-    <model id="foo" sobject="Account">
-      <fields>
-        <field id="Name"/>
-        <field id="CreatedDate"/>
-      </fields>
-    </model>
-    <model id="bar" sobject="Contact">
-      <fields>
-        <field id="Name"/>
-        <field id="CreatedDate"/>
-        <field id="Forecast" uionly="true" displaytype="FORMULA" returntype="TEXT">
-          <formula>CASE(
-    MONTH({{CreatedDate}}),
-                    1, "Snow",
-                    7, "Humidity",
-                    "Who knows"
-        )</formula>
-        </field>
-      </fields>
-    </model>
-  </models>
-  <resources>
-    <javascript>
-      <jsitem location="inline" name="SomeInlineJS">//This should be preserved
+const formula = `CASE(
+	MONTH({{CreatedDate}}),
+		1, "Snow",
+		7, "Humidity",
+		"Who knows"
+)`;
+const inlineJS = `//This should be preserved
 const foo = "bar";
 if (foo == "bar") {
-    // Indentation in here should be preserved
-    console.log("Hello: " + foo);
+		// Indentation in here should be preserved
+		console.log("Hello: " + foo);
 } else {
-    console.log("Hola: " + foo);
+		console.log("Hola: " + foo);
 }
 console.log(foo);
-</jsitem>
-    </javascript>
-  </resources>
+`;
+const getFormatted = (alternateIndent = null) => {
+	let part1 = `<skuid__page>
+	<models>
+		<model id="foo" sobject="Account">
+			<fields>
+				<field id="Name"/>
+				<field id="CreatedDate"/>
+			</fields>
+		</model>
+		<model id="bar" sobject="Contact">
+			<fields>
+				<field id="Name"/>
+				<field id="CreatedDate"/>
+				<field id="Forecast" uionly="true" displaytype="FORMULA" returntype="TEXT">
+					<formula>`;
+	let part2 = `</formula>
+				</field>
+			</fields>
+		</model>
+	</models>
+	<resources>
+		<javascript>
+			<jsitem location="inline" name="SomeInlineJS">`;
+	let part3 = `</jsitem>
+		</javascript>
+	</resources>
 </skuid__page>`;
-const condensed = `<skuid__page><models><model id="foo" sobject="Account"><fields><field id="Name"/><field id="CreatedDate"/></fields></model><model id="bar" sobject="Contact"><fields><field id="Name"/><field id="CreatedDate"/><field id="Forecast" uionly="true" displaytype="FORMULA" returntype="TEXT"><formula>CASE(
-    MONTH({{CreatedDate}}),
-                    1, "Snow",
-                    7, "Humidity",
-                    "Who knows"
-        )</formula></field></fields></model></models><resources><javascript><jsitem location="inline" name="SomeInlineJS">//This should be preserved
-const foo = "bar";
-if (foo == "bar") {
-    // Indentation in here should be preserved
-    console.log("Hello: " + foo);
-} else {
-    console.log("Hola: " + foo);
-}
-console.log(foo);
-</jsitem></javascript></resources></skuid__page>`;
+	if (alternateIndent) {
+		part1 = part1.replace(/\t/g, alternateIndent);
+		part2 = part2.replace(/\t/g, alternateIndent);
+		part3 = part3.replace(/\t/g, alternateIndent);
+	}
+	return part1 + formula + part2 + inlineJS + part3;
+};
+const condensed = `<skuid__page><models><model id="foo" sobject="Account"><fields><field id="Name"/><field id="CreatedDate"/></fields></model><model id="bar" sobject="Contact"><fields><field id="Name"/><field id="CreatedDate"/><field id="Forecast" uionly="true" displaytype="FORMULA" returntype="TEXT"><formula>${formula}</formula></field></fields></model></models><resources><javascript><jsitem location="inline" name="SomeInlineJS">${inlineJS}</jsitem></javascript></resources></skuid__page>`;
 
 describe('condenseXml', () => {
-    it("should remove recreateable whitespace from a string of XML", () => {
-        expect(condenseXml(formatted)).to.equal(condensed);
-    });
+  it("should remove recreateable whitespace from a string of XML", () => {
+    expect(condenseXml(getFormatted())).to.equal(condensed);
+  });
 });
 
 describe('formatXml', () => {
-    it("should pretty print a string of condensed XML using 2 spaces as indentation", () => {
-        expect(formatXml(condensed).replace("\r\n", "\n")).to.equal(formatted);
-    });
+  it("should pretty print a string of condensed XML using tabs as indentation by default", () => {
+		expect(formatXml(condensed).replace("\r\n", "\n")).to.equal(getFormatted());
+	});
+	it("should allow overrides of the indentation padding via environment variable", () => {
+		// override indent to 2 spaces
+		const alternateIndent = process.env.SKUID_XML_INDENT = "  ";
+		expect(formatXml(condensed).replace("\r\n", "\n")).to.equal(getFormatted(alternateIndent));
+		delete process.env.SKUID_XML_INDENT;
+	});
 });


### PR DESCRIPTION
# Summary of Changes
- (Breaking change): `skuid:page:pull` will now by default pretty-print page XML on the file system using tabs, instead of 2 spaces as it has done previously. This change was made to create consistency across all of Skuid's CLI tools and products in terms of how we pretty-print page XML when displaying it at rest on the file system and in the browser-based Page XML Editor. If customers wish to retain the previous behavior of 2 spaces, this can be done using a new `SKUID_XML_INDENT` environment variable. See the README for more details.